### PR TITLE
feat: add gnome control to openvpn

### DIFF
--- a/ansible/roles/generic/defaults/main.yml
+++ b/ansible/roles/generic/defaults/main.yml
@@ -130,6 +130,7 @@ debian_packages:
 debian_packages_gui:
   - metacity-themes
   - ubuntu-gnome-desktop
+  - network-manager-openvpn-gnome
 
 rk_email: root
 


### PR DESCRIPTION
Allows users to use openvpn routes without sudo