### PR TITLE
fix: systemctl stops apt-daily.service instead of disabling timer

### DIFF
--- a/ansible/install.sh
+++ b/ansible/install.sh
@@ -16,6 +16,7 @@ AWM=${AWM:-false}
 
 if [[ ${OS} == "debian" ]]
 then
+  systemctl stop apt-daily.service
   if [[ ! -z ${PROXY} ]]
   then
     echo "Setting Proxy to: ${PROXY}"
@@ -31,7 +32,6 @@ then
     rm -f /etc/apt/apt.conf.d/01_docker_proxy.conf
     rm -rf /root/.pip
   fi
-  systemctl disable apt-daily.timer
   apt-get -y install python-pip git libssl-dev libffi-dev
   pip install 'docker-py==1.9.0'
 fi
@@ -92,7 +92,7 @@ fi
 
 if [[ ${OS} == "debian" ]]
 then
-  systemctl enable apt-daily.timer
+  systemctl start apt-daily.service
 fi
 
 exit 0


### PR DESCRIPTION
Timer determines when the daily run occurs, so stopping it will not stop a daily run already in progress