### PR TITLE
fix: moved clamav role to end of site.yml

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -25,8 +25,8 @@
     - { role: packer }
     - { role: slack }
     - { role: sublime }
-    - { role: clamav }
     - { role: sysdig }
 #    - { role: eclipse }
     - { role: awesome-wm,
         when: awesomewm }
+    - { role: clamav }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The ansible role for clamav has been moved to the end of the list

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are currently (non-deterministic) issues with clamav checking its status that are not a priority for fixing at this point, therefore to minimise the issue the role is run last so that other tools can be successfully installed first. When provisioning the laptops the script can be re-run if necessary until the clamav role succeeds.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Via `make test`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

