### PR TITLE
feat: move gui bits to their own upstream role

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,6 @@
 ---
 - src: https://github.com/UKHomeOffice/ansible-base-role.git
-  version: 1816e55010bb96cf1070f86396556c03e3c3887b
+  version: 7b586e7c7d29ee3c1918e219a0b1e36edef23268
   name: generic
 - src: https://github.com/UKHomeOffice/ansible-gui-role.git
   version: edcded91ec07e2f843df0c539a149175c4fa0f98

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -3,5 +3,5 @@
   version: 1f00f591c9aaeae2d40b31e7f3df0efe0d375e59
   name: generic
 - src: https://github.com/UKHomeOffice/ansible-gui-role.git
-  version: edcded91ec07e2f843df0c539a149175c4fa0f98
+  version: 94d6a1558e09e2b52885d8ee0b5da03a214490a4
   name: gui

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,4 +1,7 @@
 ---
 - src: https://github.com/UKHomeOffice/ansible-base-role.git
-  version: 104d4dbb11af9347691e3bb28ff249f50a1c5f96
+  version: 1816e55010bb96cf1070f86396556c03e3c3887b
   name: generic
+- src: https://github.com/UKHomeOffice/ansible-gui-role.git
+  version: edcded91ec07e2f843df0c539a149175c4fa0f98
+  name: gui

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,6 @@
 ---
 - src: https://github.com/UKHomeOffice/ansible-base-role.git
-  version: 7b586e7c7d29ee3c1918e219a0b1e36edef23268
+  version: 1f00f591c9aaeae2d40b31e7f3df0efe0d375e59
   name: generic
 - src: https://github.com/UKHomeOffice/ansible-gui-role.git
   version: edcded91ec07e2f843df0c539a149175c4fa0f98


### PR DESCRIPTION
I have split the gui roles out in to their own upstream base role, as it appears ansible was not correctly splitting out desktop and non desktop roles.

This needs to be tested