### PR TITLE
Editting files for proxy and pxe server startups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ removeboxes:
 proxycache:
 	@vagrant up proxy --provision
 
+proxycacheSSH:
+	@vagrant ssh proxy -c "touch /tmp/testing; tail -f /tmp/testing"
+
+proxycachehalt:
+	@vagrant halt proxy
+
 box:
 	@PROXY="$(PROXY)" sed "s|PROXY|$(PROXY):3142|g" http/preseed.cfg.orig > http/preseed.cfg
 	@packer build -on-error=abort -force ubuntu-16.04.json
@@ -33,6 +39,12 @@ awmtest:
 
 pxe:
 	@PXE=$(PXE) PROXY=$(PROXY) vagrant up pxe --provision
+
+pxeSSH: 
+	@vagrant ssh pxe -c "touch /tmp/testing; tail -f /tmp/testing"
+
+pxehalt: 
+	@vagrant halt pxe
 
 develop:
 	curl https://raw.githubusercontent.com/UKHomeOffice/development_environment/develop/ansible/install.sh | GIT_REF=develop bash

--- a/README.md
+++ b/README.md
@@ -82,4 +82,25 @@ If you also want to install awesome-wm then run the following (this method is su
 ```
 export GIT_REF=develop
 curl https://raw.githubusercontent.com/UKHomeOffice/development_environment/${GIT_REF}/ansible/install.sh | AWM=true bash
+
+
+#### Vagrantfile
+
+The Vagrantfile has two lines commented out for setting the proxy and pxe public networks which includes the assignment of a network bridge similar to the following:
+
+```
+proxy.vm.network "public_network", ip: "ip_value", bridge: networks["network_bridge_value"]
+```
+
+These lines have been added to provide the option of running the vagrant up commands of both the pxe and proxy servers to run without human intervention of entering which network bridge to use. These lines are currently commented out to prevent any interference with existing users. However, if uncommented and used instead of the existing vm.network lines, then the network bridge value should be placed into a yaml file similar to the following:
+
+```
+network_bridge: 'network_bridge_value'
+```
+
+and the Vagrantfile will need to specify the location of the yaml file for it to read:
+
+```
+networks = YAML.load_file('location/network.yaml')
+
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,11 @@
+require 'yaml'
+networks = YAML.load_file('network.yaml')
+
 Vagrant.configure("2") do |config|
   config.vm.define "proxy" do |proxy|
     proxy.vm.box = "bento/ubuntu-16.04"
     proxy.vm.network "public_network", ip: "192.168.87.250"
+    #proxy.vm.network "public_network", ip: "192.168.87.250", bridge: networks["network_bridge"]
     proxy.ssh.username = "vagrant"
     proxy.ssh.password = "vagrant"
     proxy.ssh.insert_key = true
@@ -98,6 +102,7 @@ Vagrant.configure("2") do |config|
   config.vm.define "pxe" do |pxe|
     pxe.vm.box = "bento/ubuntu-16.04"
     pxe.vm.network "public_network", ip: "192.168.87.254"
+    #pxe.vm.network "public_network", ip: "192.168.87.254", bridge: networks["network_bridge"]
     pxe.ssh.username = "vagrant"
     pxe.ssh.password = "vagrant"
     pxe.ssh.insert_key = true

--- a/network.yaml
+++ b/network.yaml
@@ -1,0 +1,1 @@
+network_bridge: ''


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updated the Vagrantfile to provide the option to auto assign the public network bridge to use during the "vagrant up" of both pxe and proxy servers to disable the need of human interaction.
The Makefile has been updated to include functionality to halt both the proxy and pxe servers. It also includes an SSH command that will continuously run inside both the pxe and proxy servers whilst they are running. This keeps the processes running for systemd. The README has been updated to describe the change to the vagrantfile and a new file called networks.yaml has been added as a way to store the network bridge name.

## Motivation and Context
To enable both the proxy and pxe servers to be automatically started via systemd on system boot and to be shutdown on system shutdown.

## How Has This Been Tested?
reviewed by @robhowlett 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

