### PR TITLE
systemd files for auto start and stop of pxe and proxy vagrant boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,43 @@ and the Vagrantfile will need to specify the location of the yaml file for it to
 networks = YAML.load_file('location/network.yaml')
 
 ```
+
+
+####Systemd
+
+The directory systemd of this repo contains systemd unit files for the proxy and pxe servers. The files enable both servers to be started at system boot and halted at system shutdown. If the servers are interrupted unexpectedly, the untis will try to restart the servers. 
+
+Both unit files use the Makefile in this repo to run commands for starting and stopping the VM servers. An SSH command is also used to provide a continuous way of keeping each VM up and running after they have been successfully provisioned. This is needed because once the VM has been provisioned, systemd thinks that the process has completed successfully and no longer requires the process to be running and therefore begins to shutdown the VM. The SSH runs a tail command within an empty file on each of the servers in a continuous loop until the server is shutdown. 
+
+If running an ubuntu host machine, these files should be placed into the following location:
+
+```
+/etc/systemd/system
+```
+
+Once added, the units need to be started with the following commands:
+
+``` 
+systemctl enable proxy-vbox-vm.service
+
+systemctl enable pxe-vbox-vm.service
+``` 
+
+To check whether the units are running, run the following commands:
+
+```
+systemctl status proxy-vbox-vm.service
+
+systemctl status pxe-vbox-vm.service
+```
+
+If you make changes to the unit files, then a daemon re-load is required to reload the systemd manager configuration and recreate the dependency tree;
+
+```
+systemctl daemon-reload
+
+systemctl restart name_of_unit_service_changed
+```
+
+
+

--- a/systemd/proxy-vbox-vm.service
+++ b/systemd/proxy-vbox-vm.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Proxy VBox Virtual Machine
+Requires=systemd-modules-load.service
+After=systemd-modules-load.service
+Before=shutdown.target restart.target
+
+[Service]
+Environment=REPO=$home_path/development_environment/
+User=$user
+Group=$group
+ExecStartPre=/bin/bash -c "make proxycache -C ${REPO}"
+ExecStart=/bin/bash -c "make proxycacheSSH -C ${REPO}"
+ExecStop=/bin/bash -c "make proxycachedown -C ${REPO}"
+TimeoutStartSec=infinity
+TimeoutStopSec=60
+Restart=on-failure
+RestartSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/pxe-vbox-vm.service
+++ b/systemd/pxe-vbox-vm.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=PXE VBox Virtual Machine
+Requires=systemd-modules-load.service
+After=systemd-modules-load.service
+Before=shutdown.target restart.target
+
+[Service]
+Environment=REPO=$home_path/development_environment/
+User=$user
+Group=$group
+ExecStartPre=/bin/bash -c "make pxe -C ${REPO}"
+ExecStart=/bin/bash -c "make pxeSSH -C ${REPO}"
+ExecStop=/bin/bash -c "make pxedown -C ${REPO}"
+TimeoutStartSec=infinity
+TimeoutStopSec=60
+Restart=on-failure
+RestartSec=60
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Description
systemd files for starting and stopping vagrant pxe and proxy servers automatically.

## Motivation and Context
As part of a Jira ticket.

## How Has This Been Tested?
Reviewed by @robhowlett 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

