### PR TITLE
This change installs and configure ufw version 0.35.

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,6 +1,6 @@
 ---
 - src: https://github.com/UKHomeOffice/ansible-base-role.git
-  version: 9bc4a976623874a28d2040fd3ec983ad794a7213
+  version: d29d13bac4a5c54602ac3a6e5ad82a0916c920e9
   name: generic
 - src: https://github.com/UKHomeOffice/ansible-gui-role.git
   version: 0e6e540d6c1bc1976bea2653e20dfcba448bf9d7


### PR DESCRIPTION
This change installs and configure ufw version 0.35 on EUD. 
Testing was done and changes were reviewed. Please see the following pull requests for details: 
- https://github.com/UKHomeOffice/ansible-role-firewall/pull/4 
- https://github.com/UKHomeOffice/ansible-base-role/pull/46